### PR TITLE
Updating jekyll's Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source :rubygems
 
+gem 'iconv'
 gem 'RedCloth'
 gem 'jekyll'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'iconv'
 gem 'RedCloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.2.8)
     albino (1.3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       fast-stemmer (>= 1.0.0)
     directory_watcher (1.4.1)
     fast-stemmer (1.0.0)
+    iconv (1.0.4)
     jekyll (0.11.0)
       albino (>= 1.3.2)
       classifier (>= 1.3.1)
@@ -27,4 +28,5 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth
+  iconv
   jekyll


### PR DESCRIPTION
Just two minor changes;
- Added the newer way of calling out ruby gems to insure that we are using a https connection
- Added the iconv gem to get rid of the `maruku/input/parse_doc.rb:22:in `require': cannot load such file -- iconv (LoadError)` error
