### PR TITLE
[FIX] Readme Procfile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ Create the Gemfile.lock
 
 Create a Procfile
 
-    echo "web:	jekyll serve -P $PORT" > Procfile
+    echo "web: jekyll serve --no-watch --port $PORT --host 0.0.0.0" >> Procfile
 
 Exclude all of those files
 


### PR DESCRIPTION
     - Following the steps for the manual creation of jekyll, I recognized that heroku was not working. The issue was that it needs to have the host parameter with 0.0.0.0 in the Procfile